### PR TITLE
Feat/config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ that which is already setup via configuration files. To use:
     However, some configuration is welcomed for certain items to allow for
     efficient use of configuration files.
 
+    It is also possible to setup these variables into a configuration file, `pkictl`
+    will automatically look for these file: `pkictl.conf`, `$XDG_CONFIG_HOME/pkictl.conf`,
+    `$HOME/.pkictl.conf` and finally `/etc/pkictl/pkictl.conf`. The first file found
+    is taken into acount.
+
     * CA Settings
         * `$PKICTL_ORG`: This sets "myorg.local" in the above examples. Must be
           the same as the "organizationName" value in the openssl configuration

--- a/pkictl
+++ b/pkictl
@@ -8,6 +8,17 @@
 ##Requirements: openssl
 ##----------------
 
+# Load configuration files
+if [[ -f $PWD/pkictl.conf ]]; then
+  source $PWD/pkictl.conf
+elif [[ -f $XDG_CONFIG_HOME/pkictl.conf ]]; then
+  source $XDG_CONFIG_HOME/pkictl.conf
+elif [[ -f $HOME/.pkictl.conf ]]; then
+  source $HOME/.pkictl.conf
+elif [[ -f /etc/pkictl/pkictl.conf ]]; then
+  source /etc/pkictl/pkictl.conf
+fi
+
 # Binary settings
 export OPENSSL_BIN=${OPENSSL_BIN:-"openssl"}
 


### PR DESCRIPTION
 	feat(pkictl): add configuration file loading

This feature allows to load environment variable from a configuration
file. The configuration file should be a simple bash script where
environment variables are exported.

 	docs(README.md): add documentation for configuration file

Just the documentation