### PR TITLE
Feat/config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,11 @@ that which is already setup via configuration files. To use:
     However, some configuration is welcomed for certain items to allow for
     efficient use of configuration files.
 
-    It is also possible to setup these variables into a configuration file, `pkictl`
-    will automatically look for these file: `pkictl.conf`, `$XDG_CONFIG_HOME/pkictl.conf`,
+    It is also possible to setup these variables into a configuration file via the
+    `$PKICTL_CONF` environment variable. `pkictl` will automatically look for these 
+    file: `$PKICTL_CONF`, `$PWD/pkictl.conf`, `$XDG_CONFIG_HOME/pkictl.conf`,
     `$HOME/.pkictl.conf` and finally `/etc/pkictl/pkictl.conf`. The first file found
-    is taken into acount.
+    is taken into acount, and it will not throw any errors if files are not found.
 
     * CA Settings
         * `$PKICTL_ORG`: This sets "myorg.local" in the above examples. Must be

--- a/pkictl
+++ b/pkictl
@@ -9,12 +9,14 @@
 ##----------------
 
 # Load configuration files
-if [[ -f $PWD/pkictl.conf ]]; then
-  source $PWD/pkictl.conf
-elif [[ -f $XDG_CONFIG_HOME/pkictl.conf ]]; then
-  source $XDG_CONFIG_HOME/pkictl.conf
-elif [[ -f $HOME/.pkictl.conf ]]; then
-  source $HOME/.pkictl.conf
+if [[ -f ${PKICTL_CONF} ]]; then
+  source ${PKICTL_CONF}
+elif [[ -f ${PWD}/pkictl.conf ]]; then
+  source ${PWD}/pkictl.conf
+elif [[ -f ${XDG_CONFIG_HOME}/pkictl.conf ]]; then
+  source ${XDG_CONFIG_HOME}/pkictl.conf
+elif [[ -f ${HOME}/.pkictl.conf ]]; then
+  source ${HOME}/.pkictl.conf
 elif [[ -f /etc/pkictl/pkictl.conf ]]; then
   source /etc/pkictl/pkictl.conf
 fi


### PR DESCRIPTION
 	feat(pkictl): add support for custom config file

This allows to use a completely different root for configuration. This
commit also fix change shell variables $VAR to ${VAR}. This is a
cosmetic change/fix.

 	docs(README.md): add documentation for PKICTL_CONF

Update the documentation.